### PR TITLE
Add tests for product listing route

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,12 @@ Simple Flask web app to manage farm product reservations.
    flask run
    ```
 5. Open `http://localhost:5000` in your browser.
+
+## Running Tests
+
+Install `pytest` and run the tests from the repository root:
+
+```bash
+pip install pytest
+pytest
+```

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,15 @@
+import pytest
+from app import create_app
+
+@pytest.fixture
+def client():
+    app = create_app()
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        yield client
+
+def test_product_listing(client):
+    response = client.get('/')
+    assert response.status_code == 200
+    # Ensure at least one product name appears in the response
+    assert b'Apples' in response.data


### PR DESCRIPTION
## Summary
- add a pytest-based test suite
- show how to run tests in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847c371c7d48322bd870efc17cba549