### PR TITLE
Add database models and seeding command

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,16 @@ Simple Flask web app to manage farm product reservations.
    ```bash
    pip install -r requirements.txt
    ```
-4. Run the application:
+4. Initialize the database with sample data:
    ```bash
    export FLASK_APP=app
+   flask init-db
+   ```
+5. Run the application:
+   ```bash
    flask run
    ```
-5. Open `http://localhost:5000` in your browser.
+6. Open `http://localhost:5000` in your browser.
 
 ## Running Tests
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,11 +1,44 @@
 from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+
+# SQLAlchemy database instance
+db = SQLAlchemy()
 
 # create and configure the app
 
 def create_app():
+    """Application factory."""
     app = Flask(__name__)
+
+    # Default configuration uses local SQLite database
+    app.config.setdefault("SQLALCHEMY_DATABASE_URI", "sqlite:///app.db")
+    app.config.setdefault("SQLALCHEMY_TRACK_MODIFICATIONS", False)
+
+    db.init_app(app)
 
     from .routes import bp as routes_bp
     app.register_blueprint(routes_bp)
 
+    register_cli_commands(app)
+
     return app
+
+
+def register_cli_commands(app):
+    """Register custom CLI commands."""
+    @app.cli.command("init-db")
+    def init_db_command():
+        """Initialize the database with default data."""
+        from .models import Product
+
+        db.drop_all()
+        db.create_all()
+
+        initial_products = [
+            Product(name="Apples", quantity=20),
+            Product(name="Oranges", quantity=15),
+            Product(name="Potatoes", quantity=30),
+        ]
+        db.session.add_all(initial_products)
+        db.session.commit()
+        print("Initialized the database with sample data.")

--- a/app/models.py
+++ b/app/models.py
@@ -1,8 +1,21 @@
-# Simple in-memory data store
-products = [
-    {'id': 1, 'name': 'Apples', 'quantity': 20},
-    {'id': 2, 'name': 'Oranges', 'quantity': 15},
-    {'id': 3, 'name': 'Potatoes', 'quantity': 30},
-]
+"""Database models for the application."""
 
-reservations = []
+from . import db
+
+
+class Product(db.Model):
+    """A farm product available for reservation."""
+
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(80), nullable=False)
+    quantity = db.Column(db.Integer, nullable=False)
+
+
+class Reservation(db.Model):
+    """A reservation for a specific product."""
+
+    id = db.Column(db.Integer, primary_key=True)
+    product_id = db.Column(db.Integer, db.ForeignKey("product.id"), nullable=False)
+
+    product = db.relationship(Product, backref=db.backref("reservations", lazy=True))
+

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,14 +1,18 @@
 from flask import Blueprint, render_template, redirect, url_for
-from .models import products, reservations
+from .models import Product, Reservation
+from . import db
 
 bp = Blueprint('routes', __name__)
 
 @bp.route('/')
 def index():
+    products = Product.query.all()
     return render_template('index.html', products=products)
 
 @bp.route('/reserve/<int:product_id>')
 def reserve(product_id):
-    if product_id not in reservations:
-        reservations.append(product_id)
+    if not Reservation.query.filter_by(product_id=product_id).first():
+        reservation = Reservation(product_id=product_id)
+        db.session.add(reservation)
+        db.session.commit()
     return redirect(url_for('routes.index'))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask
+Flask-SQLAlchemy
 SQLAlchemy

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,10 +1,20 @@
 import pytest
-from app import create_app
+from app import create_app, db
+from app.models import Product
 
 @pytest.fixture
 def client():
     app = create_app()
     app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        db.create_all()
+        db.session.add_all([
+            Product(name='Apples', quantity=20),
+            Product(name='Oranges', quantity=15),
+            Product(name='Potatoes', quantity=30),
+        ])
+        db.session.commit()
     with app.test_client() as client:
         yield client
 


### PR DESCRIPTION
## Summary
- add Product and Reservation models
- configure SQLAlchemy with Flask
- implement `init-db` CLI command for seeding sample data
- update routes to use the database
- update tests to prepare an in-memory database
- document initialization steps in README
- add Flask-SQLAlchemy to requirements

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847ca06ac6083229788f40e227a4a9b