### PR TITLE
Add Flask-WTF reservation form

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -11,6 +11,8 @@ def create_app():
     app = Flask(__name__)
 
     # Default configuration uses local SQLite database
+    if not app.config.get("SECRET_KEY"):
+        app.config["SECRET_KEY"] = "dev-secret-key"
     app.config.setdefault("SQLALCHEMY_DATABASE_URI", "sqlite:///app.db")
     app.config.setdefault("SQLALCHEMY_TRACK_MODIFICATIONS", False)
 

--- a/app/forms.py
+++ b/app/forms.py
@@ -1,0 +1,20 @@
+from flask_wtf import FlaskForm
+from wtforms import HiddenField, SubmitField
+from wtforms.validators import DataRequired, ValidationError
+
+from .models import Product, Reservation
+
+class ReservationForm(FlaskForm):
+    """Form to reserve a product."""
+
+    product_id = HiddenField(validators=[DataRequired()])
+    submit = SubmitField('Reserve')
+
+    def validate_product_id(self, field):
+        product = Product.query.get(field.data)
+        if not product:
+            raise ValidationError('Product not found.')
+        # Count existing reservations
+        count = Reservation.query.filter_by(product_id=field.data).count()
+        if count >= product.quantity:
+            raise ValidationError('No more stock available.')

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,5 +1,6 @@
-from flask import Blueprint, render_template, redirect, url_for
+from flask import Blueprint, render_template, redirect, url_for, request
 from .models import Product, Reservation
+from .forms import ReservationForm
 from . import db
 
 bp = Blueprint('routes', __name__)
@@ -7,12 +8,14 @@ bp = Blueprint('routes', __name__)
 @bp.route('/')
 def index():
     products = Product.query.all()
-    return render_template('index.html', products=products)
+    forms = {p.id: ReservationForm(product_id=p.id) for p in products}
+    return render_template('index.html', products=products, forms=forms)
 
-@bp.route('/reserve/<int:product_id>')
-def reserve(product_id):
-    if not Reservation.query.filter_by(product_id=product_id).first():
-        reservation = Reservation(product_id=product_id)
+@bp.route('/reserve', methods=['POST'])
+def reserve():
+    form = ReservationForm()
+    if form.validate_on_submit():
+        reservation = Reservation(product_id=form.product_id.data)
         db.session.add(reservation)
         db.session.commit()
     return redirect(url_for('routes.index'))

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -9,7 +9,10 @@
       {% for item in products %}
       <li>
         {{ item.name }} ({{ item.quantity }})
-        <a href="{{ url_for('routes.reserve', product_id=item.id) }}">Reserve</a>
+        <form action="{{ url_for('routes.reserve') }}" method="post" style="display:inline;">
+          {{ forms[item.id].hidden_tag() }}
+          {{ forms[item.id].submit() }}
+        </form>
       </li>
       {% endfor %}
     </ul>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask
 Flask-SQLAlchemy
 SQLAlchemy
+Flask-WTF


### PR DESCRIPTION
## Summary
- introduce Flask-WTF dependency
- add reservation form with stock validation
- add CSRF secret configuration
- process reservation form in new `/reserve` POST route
- update template to use the new form

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847ccbddb9c83228cf18bfd16b28875